### PR TITLE
Fix editor JavaScript path

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -42,7 +42,7 @@
                     + Add Tweet
                 </button>
             </div>
-            <script defer src="static/js/main.js"></script>
+            <script defer src="main.js"></script>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This PR sixes the path to the main.js, which was wrong after migrating from the original repository. Currently, the editor doesn't really work.